### PR TITLE
ml2_conf.ini.erb with [eswitch] section

### DIFF
--- a/templates/default/plugins/ml2/ml2_conf.ini.erb
+++ b/templates/default/plugins/ml2/ml2_conf.ini.erb
@@ -70,3 +70,7 @@ enable_security_group = <%= node['openstack']['network']['ml2']['enable_security
 # Use ipset to speed-up the iptables security groups. Enabling ipset support
 # requires that ipset is installed on L2 agent node.
 enable_ipset = <%= node['openstack']['network']['ml2']['enable_ipset'] %>
+
+[eswitch]
+vnic_type = hostdev
+apply_profile_patch = True


### PR DESCRIPTION
Previously, the ml2_conf.ini included in the cookbook did not contain an [eswitch] section needed for cookbook-openstack-mellanox. This PR incorporates this section.
