### PR TITLE
Use separate values in l3_agent.ini and in dhcp_agent.ini

### DIFF
--- a/templates/default/l3_agent.ini.erb
+++ b/templates/default/l3_agent.ini.erb
@@ -9,7 +9,7 @@ debug = <%= node["openstack"]["network"]["debug"] %>
 
 # Example of interface_driver option for OVS based plugins (OVS, Ryu, NEC)
 # that supports L3 agent
-interface_driver = <%= node["openstack"]["network"]["l3_interface_driver"] %>
+interface_driver = <%= node["openstack"]["network"]["l3"]["interface_driver"] %>
 
 # Use veth for an OVS interface or not.
 # Support kernels with limited namespace support

--- a/templates/default/l3_agent.ini.erb
+++ b/templates/default/l3_agent.ini.erb
@@ -9,7 +9,7 @@ debug = <%= node["openstack"]["network"]["debug"] %>
 
 # Example of interface_driver option for OVS based plugins (OVS, Ryu, NEC)
 # that supports L3 agent
-interface_driver = <%= node["openstack"]["network"]["interface_driver"] %>
+interface_driver = <%= node["openstack"]["network"]["l3_interface_driver"] %>
 
 # Use veth for an OVS interface or not.
 # Support kernels with limited namespace support


### PR DESCRIPTION
Previously node['openstack']['network']['interface_driver'] was used for both l3_agent.ini and in dhcp_agent.ini. But cookbook-openstack-mellanox requires to set different values in both
